### PR TITLE
[41기 이다혜] Feature/navfunction 로그아웃 기능 & 반응형 nav바 구현

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { Link, Navigate } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { CiSearch } from 'react-icons/ci';
 import { BsCart3 } from 'react-icons/bs';
 import { HiOutlineBars3 } from 'react-icons/hi2';
@@ -8,6 +8,7 @@ import './Nav.scss';
 
 const Nav = () => {
   const [currentScroll, setCurrentScroll] = useState(0);
+  const navigate = useNavigate();
 
   useEffect(() => {
     window.addEventListener('scroll', handleScroll);
@@ -20,58 +21,39 @@ const Nav = () => {
     setCurrentScroll(window.scrollY);
   };
 
-  const logOut = () => {
-    localStorage.clear();
-  };
+  const isTokenValid = localStorage.getItem('Token');
 
-  const isTokenValid = () => {
-    localStorage.getItem('Token');
+  const handleLoginUserNav = (e, to) => {
+    if (e.target.title === '로그아웃') {
+      localStorage.clear();
+    }
+    navigate(`${to}`);
   };
 
   return (
     <div className="nav">
       <div className="linkWrap">
         <div className="memberLink">
-          {/* {isTokenValid
+          {isTokenValid
             ? LOGIN_LIST.map(list => {
                 return (
-                  <Link className="memberLinkStyle" to={list.to} key={list.id}>
+                  <span
+                    className="memberLinkStyle"
+                    key={list.id}
+                    title={list.title}
+                    onClick={e => handleLoginUserNav(e, list.to)}
+                  >
                     {list.title}
-                  </Link>
+                  </span>
                 );
               })
             : LINK_LIST.map(list => {
                 return (
-                  <Link className="memberLinkStyle" to={list.to} key={list.id}>
+                  <Link className="memberLinkStyle" key={list.id} to={list.to}>
                     {list.title}
                   </Link>
                 );
-              })} */}
-          {/* {LOGIN_LIST.map(list => {
-            return (
-              <Link className="memberLinkStyle" to={list.to} key={list.id}>
-                {list.title}
-              </Link>
-            );
-          })} */}
-          <Link className="memberLinkStyle" to="/signup">
-            회원가입
-          </Link>
-          <Link className="memberLinkStyle" to="/">
-            로그인
-          </Link>
-          <Link className="memberLinkStyle" to="/">
-            고객센터
-          </Link>
-          <Link className="memberLinkStyle" to="/">
-            마이페이지
-          </Link>
-          <Link className="memberLinkStyle" to="/" onClick={logOut}>
-            로그아웃
-          </Link>
-          <Link className="memberLinkStyle" to="/">
-            고객센터
-          </Link>
+              })}
         </div>
         <div className="navMain">
           <Link to="/" className="navLogo">

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -19,10 +19,22 @@ const Nav = () => {
     setCurrentScroll(window.scrollY);
   };
 
+  const isTokenValid = () => {
+    localStorage.getItem('Token');
+  };
+
   return (
     <div className="nav">
       <div className="linkWrap">
-        <div className="memberLink" />
+        <div className="memberLink">
+          {LINK_LIST.map(list => {
+            return (
+              <Link className="memberLinkStyle" to={list.to} key={list.id}>
+                {list.title}
+              </Link>
+            );
+          })}
+        </div>
         <div className="navMain">
           <Link to="/" className="navLogo">
             SIMPLE
@@ -61,4 +73,5 @@ const Nav = () => {
     </div>
   );
 };
+
 export default Nav;

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import { CiSearch } from 'react-icons/ci';
 import { BsCart3 } from 'react-icons/bs';
 import { HiOutlineBars3 } from 'react-icons/hi2';
@@ -8,6 +8,7 @@ import './Nav.scss';
 
 const Nav = () => {
   const [currentScroll, setCurrentScroll] = useState(0);
+
   useEffect(() => {
     window.addEventListener('scroll', handleScroll);
     return () => {
@@ -19,6 +20,10 @@ const Nav = () => {
     setCurrentScroll(window.scrollY);
   };
 
+  const logOut = () => {
+    localStorage.clear();
+  };
+
   const isTokenValid = () => {
     localStorage.getItem('Token');
   };
@@ -27,13 +32,28 @@ const Nav = () => {
     <div className="nav">
       <div className="linkWrap">
         <div className="memberLink">
-          {LINK_LIST.map(list => {
+          {isTokenValid
+            ? LOGIN_LIST.map(list => {
+                return (
+                  <Link className="memberLinkStyle" to={list.to} key={list.id}>
+                    {list.title}
+                  </Link>
+                );
+              })
+            : LINK_LIST.map(list => {
+                return (
+                  <Link className="memberLinkStyle" to={list.to} key={list.id}>
+                    {list.title}
+                  </Link>
+                );
+              })}
+          {/* {LOGIN_LIST.map(list => {
             return (
               <Link className="memberLinkStyle" to={list.to} key={list.id}>
                 {list.title}
               </Link>
             );
-          })}
+          })} */}
         </div>
         <div className="navMain">
           <Link to="/" className="navLogo">

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -32,7 +32,7 @@ const Nav = () => {
     <div className="nav">
       <div className="linkWrap">
         <div className="memberLink">
-          {isTokenValid
+          {/* {isTokenValid
             ? LOGIN_LIST.map(list => {
                 return (
                   <Link className="memberLinkStyle" to={list.to} key={list.id}>
@@ -46,7 +46,7 @@ const Nav = () => {
                     {list.title}
                   </Link>
                 );
-              })}
+              })} */}
           {/* {LOGIN_LIST.map(list => {
             return (
               <Link className="memberLinkStyle" to={list.to} key={list.id}>
@@ -54,6 +54,24 @@ const Nav = () => {
               </Link>
             );
           })} */}
+          <Link className="memberLinkStyle" to="/signup">
+            회원가입
+          </Link>
+          <Link className="memberLinkStyle" to="/">
+            로그인
+          </Link>
+          <Link className="memberLinkStyle" to="/">
+            고객센터
+          </Link>
+          <Link className="memberLinkStyle" to="/">
+            마이페이지
+          </Link>
+          <Link className="memberLinkStyle" to="/" onClick={logOut}>
+            로그아웃
+          </Link>
+          <Link className="memberLinkStyle" to="/">
+            고객센터
+          </Link>
         </div>
         <div className="navMain">
           <Link to="/" className="navLogo">

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { CiSearch } from 'react-icons/ci';
 import { BsCart3 } from 'react-icons/bs';
@@ -7,9 +7,15 @@ import { LINK_LIST, LINKBTM_LIST } from './NavData.js';
 import './Nav.scss';
 
 const Nav = () => {
+  const navRef = useRef();
+  const navY = navRef.current.offsetTop;
+
+  console.log(navRef.current); // 출력됐다가 안됐다가
+  console.log(navY);
+
   return (
     <div className="nav">
-      <div className="linkWrap">
+      <div className="linkWrap" ref={navRef.current}>
         <div className="memberLink">
           {LINK_LIST.map(list => {
             return (

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -8,14 +8,14 @@ import './Nav.scss';
 
 const Nav = () => {
   const navRef = useRef();
-  const navY = navRef.current.offsetTop;
+  const navTop = navRef.current.offsetTop;
 
   console.log(navRef.current); // 출력됐다가 안됐다가
-  console.log(navY);
+  console.log(navTop);
 
   return (
     <div className="nav">
-      <div className="linkWrap" ref={navRef.current}>
+      <div className="linkWrap" ref={navTop}>
         <div className="memberLink">
           {LINK_LIST.map(list => {
             return (

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -1,30 +1,28 @@
-import React, { useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { CiSearch } from 'react-icons/ci';
 import { BsCart3 } from 'react-icons/bs';
 import { HiOutlineBars3 } from 'react-icons/hi2';
-import { LINK_LIST, LINKBTM_LIST } from './NavData.js';
+import { LINK_LIST, LOGIN_LIST, LINKBTM_LIST } from './NavData.js';
 import './Nav.scss';
 
 const Nav = () => {
-  const navRef = useRef();
-  const navTop = navRef.current.offsetTop;
+  const [currentScroll, setCurrentScroll] = useState(0);
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
 
-  console.log(navRef.current); // 출력됐다가 안됐다가
-  console.log(navTop);
+  const handleScroll = () => {
+    setCurrentScroll(window.scrollY);
+  };
 
   return (
     <div className="nav">
-      <div className="linkWrap" ref={navTop}>
-        <div className="memberLink">
-          {LINK_LIST.map(list => {
-            return (
-              <Link className="memberLinkStyle" to={list.to} key={list.id}>
-                {list.title}
-              </Link>
-            );
-          })}
-        </div>
+      <div className="linkWrap">
+        <div className="memberLink" />
         <div className="navMain">
           <Link to="/" className="navLogo">
             SIMPLE
@@ -52,7 +50,13 @@ const Nav = () => {
             );
           })}
         </div>
-        <div className="blank" />
+        <div className="blank">
+          {currentScroll >= 110 && (
+            <Link to="/cart">
+              <BsCart3 className="navCartScroll" />
+            </Link>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -1,8 +1,16 @@
 @import '../../styles/variables';
 
 .nav {
-  z-index: 1;
+  position: sticky;
+  z-index: 2;
+  top: -90px;
+  width: 100vw;
+  height: 141px;
+
   .linkWrap {
+    height: 100px;
+    background-color: white;
+
     .memberLink {
       display: flex;
       justify-content: flex-end;
@@ -58,6 +66,8 @@
       }
 
       .navCart {
+        position: sticky;
+        top: -98px;
         width: 30px;
         height: 35px;
         color: $color-main;
@@ -67,11 +77,16 @@
 
   .categoryWrap {
     display: flex;
+    position: sticky;
+    top: 0;
     align-items: center;
     justify-content: space-around;
-    margin: 0px 10px;
+    width: 100%;
+    height: 41px;
+    padding: 0px 10px 10px;
     padding-bottom: 10px;
     border-bottom: 1px solid rgba(143, 116, 87, 0.302);
+    background-color: white;
     color: $color-main;
 
     &Left {
@@ -96,6 +111,15 @@
       font-weight: 600;
 
       &Li {
+        color: $color-main;
+        text-decoration: none;
+      }
+    }
+
+    .blank {
+      .navCartScroll {
+        width: 25px;
+        height: 30px;
         color: $color-main;
         text-decoration: none;
       }

--- a/src/components/Nav/NavData.js
+++ b/src/components/Nav/NavData.js
@@ -5,7 +5,7 @@ export const LINK_LIST = [
 ];
 
 export const LOGIN_LIST = [
-  { id: 1, to: '/', title: '마이페이지' },
+  { id: 1, to: '/mypage', title: '마이페이지' },
   { id: 2, to: '/', title: '로그아웃' },
   { id: 3, to: '/', title: '고객센터' },
 ];

--- a/src/components/Nav/NavData.js
+++ b/src/components/Nav/NavData.js
@@ -4,6 +4,12 @@ export const LINK_LIST = [
   { id: 3, to: '/', title: '고객센터' },
 ];
 
+export const LOGIN_LIST = [
+  { id: 1, to: '/', title: '마이페이지' },
+  { id: 2, to: '/', title: '로그아웃' },
+  { id: 3, to: '/', title: '고객센터' },
+];
+
 export const LINKBTM_LIST = [
   { id: 1, to: '/', title: '추천' },
   { id: 2, to: '/', title: '신제품' },


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 반응형 nav바 기능
- 로그아웃 기능

<br />

## :: 구현 사항 설명 
1. 반응형 nav 바
- 부모 태그에 높이를 설정합니다 (id="root")
- div1, div2를 감싸는 부모태그에 position:sticky 속성을 적용합니다.  div2를 맨위에 붙일예정이기 때문에 90정도의 픽셀을 top: -90px 으로 적용합니다.
<img width="729" alt="스크린샷 2023-01-09 오후 9 42 31" src="https://user-images.githubusercontent.com/75000708/211471209-21d6f515-cd82-4888-902e-ead6446dea09.png">
- div2 에 sticky를 top에서 0만큼 떨어진 위치에 적용합니다.
- 축소되었을 떄 장바구니 버튼이 출력될 수 있게 조건문을 작성합니다.
- 조건문에 필요한 state와 useeffect를 선언합니다. useeffect의 window.addEventListener는 스크롤될때 handleScroll 함수를 실행하며 재랜더링될 때는 return 함수로 해당 내용을 지워줍니다. handleScroll은 웹의 Y축 값을 출력하여 setCurrentScroll로 보내줍니다.

2. 로그아웃 기능
- getitem()메서드를 쓴 isTokenValid 함수로 토큰의 여부를 판단하여 삼항연산자로 LOGIN_LIST / LINK_LIST를 실행합니다.
- LOGIN_LIST.map은 span 태그로 출력되며 onClick 이벤트가 있습니다. span에서 클릭이벤트가 일어날때 handleLoginUserNav 함수가 실행됩니다. 함수에는 e와 list.to 인자값을 전달합니다.
- handleLoginUserNav는 e와 list.to 인자값을 받고 만약 실행된 e.target (span태그)의 title (link.title) 이 '로그아웃'과 같은 경우엔 토큰을 지워줍니다. 또한 handleLoginUserNav는 link.to 페이지로 navigate합니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 제 코드에는 부모의 높이가 적용되어있지 않아서 sticky가 적용되지 않았었습니다. div1과 div2를 감싸는 부모 태그에 높이를 안주었습니다. 하지만 부모 태그에 높이를 주어도 생기는 문제가 있었습니다. 사례들을 살펴보다 sticky가 부모 요소 안에서만 적용된다는 것을 알게되었는데 앞의 이유 때문에 부모 태그에 높이를 준다고 해도 div2는 웹 전체가 아닌 네비게이션 바의 높이 안에서만 실행될 것이기 때문입니다. 그렇다고 컴포넌트를 분리해 놓은 지금 <body> 컴포넌트에 카테고리를 적는 건 안될 것 같았습니다. 그래서 위와 같이 div의 부모 태그인 <div>에 min-height으로 최소 높이를 지정해주었습니다.
- 이미 link 로 구성된 상수데이터를 span으로 변경하여 onClick을 조건부 함수화 할 수 있는 방법에 대해 이해했습니다.
- handleLoginUserNav 에서 전달받은 to 인자를 템플릿 리터럴로 표현하여 예측불가능한 상황에 대해 대처할 수 있는 방법을 알게되었습니다. 링크의 주소에 숫자가 포함되는 경우를 생각하여 `${to}`라는 스트링으로 받는 방법에 대해 이해했습니다.

<br />

## :: 기타 질문 및 특이 사항
